### PR TITLE
Fix CSP headers for Google Analytics and separate production config

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -44,10 +44,13 @@ Comprehensive configuration for the Cutty (List Cutter) application - a Django t
 @include .claude/development-commands.yml#CronTriggerDeployment
 
 ## Git Worktree Management
+**CRITICAL: ALL worktrees MUST be created in `worktrees/` directory**
 - All debugging and feature worktrees should be created in `worktrees/` directory within this project
 - Use naming convention: `worktrees/[purpose]`
 - Example: `git worktree add worktrees/debug`
+- Example: `git worktree add worktrees/google-oauth-signin`
 - This keeps worktrees organized within the project structure
+- **NEVER create worktrees outside the worktrees/ folder**
 
 ## Testing Philosophy
 **CRITICAL: NEVER overengineer tests**
@@ -93,6 +96,9 @@ npm run build && npx wrangler versions upload --dry-run
 
 # Deploy to staging
 wrangler deploy --env=staging
+
+# Deploy to production (using separate config)
+wrangler deploy --config wrangler.prod.toml
 
 # Deploy cron triggers (priority triggers)
 wrangler triggers deploy --cron "*/5 * * * *"  # Metrics & alerts every 5 min

--- a/.claude/debugging-lessons.yml
+++ b/.claude/debugging-lessons.yml
@@ -143,7 +143,8 @@ CloudflarePagesVsWorkersDeployment: &CloudflarePagesVsWorkersDeployment
   resolution_steps:
     - "Identified build command was Pages-style instead of Workers deployment"
     - "Updated wrangler.toml: directory = '../../app/frontend/dist' (not 'dist')"
-    - "Set correct Workers build command: 'cd ../../app/frontend && npm ci && npm run build && cd ../../cloudflare/workers && npm ci && npm run build && wrangler deploy'"
+    - "Created separate wrangler.prod.toml for production deployment"
+    - "Set correct Workers build command: 'cd ../../app/frontend && npm ci && npm run build && cd ../../cloudflare/workers && npm ci && npm run build && wrangler deploy --config wrangler.prod.toml'"
     - "Verified GitHub Actions CI continues to work with Workers-only builds"
 
   warning_signs:

--- a/.claude/project-config.yml
+++ b/.claude/project-config.yml
@@ -42,10 +42,12 @@ WranglerCommands: &WranglerCommands
 
 ProjectStructure: &ProjectStructure
   main_application: "Django backend with React frontend"
-  target_deployment: "Single Cloudflare Worker 'cutty' with D1 + R2"
+  target_deployment: "Separate Cloudflare Workers for dev/prod with D1 + R2"
   migration_tools: "Comprehensive Python scripts for file migration"
-  identity_preference: "Use single worker 'cutty' for unified architecture"
-  architecture_note: "Consolidated from multiple workers (cutty-api, cutty-workers, cutty-frontend) to single worker 'cutty'"
+  deployment_configs:
+    development: "wrangler.toml - cutty-dev worker"
+    production: "wrangler.prod.toml - cutty worker"
+  architecture_note: "Clean separation: dev worker 'cutty-dev' and production worker 'cutty' with separate configurations"
 
 CommitStandards: &CommitStandards
   frequency: "Make frequent, small commits rather than large monolithic changes"

--- a/app/frontend/public/_headers
+++ b/app/frontend/public/_headers
@@ -53,4 +53,4 @@
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: geolocation=(), microphone=(), camera=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' http://localhost:8788 https://*.emily-cogsdill.workers.dev
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: https://www.google-analytics.com; connect-src 'self' http://localhost:8788 https://*.emily-cogsdill.workers.dev https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://stats.g.doubleclick.net

--- a/app/frontend/src/worker.js
+++ b/app/frontend/src/worker.js
@@ -22,7 +22,7 @@ export default {
       // Dynamic CSP based on environment
       const apiOrigins = getApiOrigins(env.ENVIRONMENT);
       response.headers.set('Content-Security-Policy', 
-        `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' ${apiOrigins}`
+        `default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: https://www.google-analytics.com; connect-src 'self' ${apiOrigins} https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://stats.g.doubleclick.net`
       );
       
       // Set caching headers based on file type
@@ -63,7 +63,7 @@ export default {
         'X-XSS-Protection': '1; mode=block',
         'Referrer-Policy': 'strict-origin-when-cross-origin',
         'Permissions-Policy': 'geolocation=(), microphone=(), camera=()',
-        'Content-Security-Policy': `default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' ${apiOrigins}`
+        'Content-Security-Policy': `default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: https://www.google-analytics.com; connect-src 'self' ${apiOrigins} https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://stats.g.doubleclick.net`
       }
     });
     

--- a/cloudflare/workers/src/config/security-config.ts
+++ b/cloudflare/workers/src/config/security-config.ts
@@ -390,7 +390,7 @@ export class SecurityConfigManager {
       },
       
       headers: {
-        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self';",
+        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https: https://www.google-analytics.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://www.googletagmanager.com https://stats.g.doubleclick.net;",
         strictTransportSecurity: 'max-age=31536000; includeSubDomains',
         xFrameOptions: 'DENY',
         xContentTypeOptions: 'nosniff',

--- a/cloudflare/workers/wrangler.prod.toml
+++ b/cloudflare/workers/wrangler.prod.toml
@@ -1,0 +1,94 @@
+name = "cutty"
+routes = [
+  { pattern = "cutty.emilycogsdill.com/*", zone_name = "emilycogsdill.com" }
+]
+main = "src/index.ts"
+compatibility_date = "2024-12-30"
+compatibility_flags = ["nodejs_compat"]
+workers_dev = true
+
+# Asset configuration for serving frontend
+[assets]
+directory = "../../app/frontend/dist"
+binding = "ASSETS"
+
+# Enable Wrangler logs (v3.88.0+)
+[observability.logs]
+enabled = true
+
+# Development configuration
+[dev]
+port = 8789
+local_protocol = "http"
+ip = "127.0.0.1"
+
+# Build configuration - optimized for faster deployment
+[build]
+command = "npm run build"
+cwd = "."
+watch_dir = "src"
+
+# Upload optimization
+upload_source_maps = false
+minify = true
+
+# Environment variables (non-sensitive) - PRODUCTION VALUES
+[vars]
+ENVIRONMENT = "production"
+API_VERSION = "v1"
+CORS_ORIGIN = "https://cutty.emilycogsdill.com"
+MAX_FILE_SIZE = "52428800" # 50MB in bytes
+JWT_ISSUER = "cutty"
+JWT_AUDIENCE = "cutty"
+SECURITY_PERFORMANCE_THRESHOLD = "100"
+SECURITY_METRICS_RETENTION_DAYS = "30"
+SECURITY_ENABLE_REAL_TIME_MONITORING = "true"
+# Production secrets are managed via Cloudflare Workers secrets:
+# JWT_SECRET - Set via: wrangler secret put JWT_SECRET --config wrangler.prod.toml
+# API_KEY_SALT - Set via: wrangler secret put API_KEY_SALT --config wrangler.prod.toml
+# These secrets are automatically available to the worker at runtime
+
+# D1 Database bindings - PRODUCTION
+[[d1_databases]]
+binding = "DB"
+database_name = "cutty-prod"
+database_id = "a26d5109-83c1-48d4-a814-6bd72bb35e51"
+migrations_dir = "./migrations"
+migrations_table = "d1_migrations"
+
+# R2 Storage bindings - PRODUCTION
+[[r2_buckets]]
+binding = "FILE_STORAGE"
+bucket_name = "cutty-files-prod"
+preview_bucket_name = "cutty-files-dev"
+
+# Security KV Namespaces (Production)
+[[kv_namespaces]]
+binding = "CUTTY_SECURITY_CONFIG"
+id = "a6973edd26304221934017997dbd147e"
+preview_id = "a6973edd26304221934017997dbd147e"
+
+[[kv_namespaces]]
+binding = "CUTTY_SECURITY_EVENTS"
+id = "e696502dea8942a8acb47e2ac474e248"
+preview_id = "e696502dea8942a8acb47e2ac474e248"
+
+[[kv_namespaces]]
+binding = "CUTTY_SECURITY_METRICS"
+id = "805adc47af9c4e8aa7ddf5b412ea3083"
+preview_id = "805adc47af9c4e8aa7ddf5b412ea3083"
+
+[[kv_namespaces]]
+binding = "CUTTY_QUOTA_TRACKING"
+id = "4c1a53aaab2846a3b11ee39416e6b1dd"
+preview_id = "4c1a53aaab2846a3b11ee39416e6b1dd"
+
+[[kv_namespaces]]
+binding = "AUTH_KV"
+id = "c490355daf9b4b84b484303d08c42eb2"
+preview_id = "c490355daf9b4b84b484303d08c42eb2"
+
+# Analytics Engine binding - Required for monitoring
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "cutty-metrics-prod"

--- a/cloudflare/workers/wrangler.toml
+++ b/cloudflare/workers/wrangler.toml
@@ -201,64 +201,6 @@ binding = "AUTH_KV"
 id = "c490355daf9b4b84b484303d08c42eb2"
 preview_id = "c490355daf9b4b84b484303d08c42eb2"
 
-# Production environment - same worker, different routes and vars
-[env.production]
-[env.production.vars]
-ENVIRONMENT = "production"
-API_VERSION = "v1"
-CORS_ORIGIN = "https://cutty.emilycogsdill.com"
-MAX_FILE_SIZE = "52428800"
-JWT_ISSUER = "cutty"
-JWT_AUDIENCE = "cutty"
-SECURITY_PERFORMANCE_THRESHOLD = "100"
-SECURITY_METRICS_RETENTION_DAYS = "30"
-SECURITY_ENABLE_REAL_TIME_MONITORING = "true"
-# Production secrets should be set via wrangler secret put JWT_SECRET
-# Production secrets should be set via wrangler secret put API_KEY_SALT
-
-[[env.production.routes]]
-pattern = "cutty.emilycogsdill.com/*"
-zone_name = "emilycogsdill.com"
-
-[[env.production.d1_databases]]
-binding = "DB"
-database_name = "cutty-prod"
-database_id = "a26d5109-83c1-48d4-a814-6bd72bb35e51"
-
-[[env.production.r2_buckets]]
-binding = "FILE_STORAGE"
-bucket_name = "cutty-files-prod"
-preview_bucket_name = "cutty-files-dev"
-
-[[env.production.analytics_engine_datasets]]
-binding = "ANALYTICS"
-dataset = "cutty-metrics-prod"
-
-# Copy KV namespaces for production  
-[[env.production.kv_namespaces]]
-binding = "CUTTY_SECURITY_CONFIG"
-id = "a6973edd26304221934017997dbd147e"
-preview_id = "a6973edd26304221934017997dbd147e"
-
-[[env.production.kv_namespaces]]
-binding = "CUTTY_SECURITY_EVENTS"
-id = "e696502dea8942a8acb47e2ac474e248"
-preview_id = "e696502dea8942a8acb47e2ac474e248"
-
-[[env.production.kv_namespaces]]
-binding = "CUTTY_SECURITY_METRICS"
-id = "805adc47af9c4e8aa7ddf5b412ea3083"
-preview_id = "805adc47af9c4e8aa7ddf5b412ea3083"
-
-[[env.production.kv_namespaces]]
-binding = "CUTTY_QUOTA_TRACKING"
-id = "4c1a53aaab2846a3b11ee39416e6b1dd"
-preview_id = "4c1a53aaab2846a3b11ee39416e6b1dd"
-
-[[env.production.kv_namespaces]]
-binding = "AUTH_KV"
-id = "c490355daf9b4b84b484303d08c42eb2"
-preview_id = "c490355daf9b4b84b484303d08c42eb2"
 
 # Service bindings will be configured when needed
 # Future service configuration will go here


### PR DESCRIPTION
## Summary
Fixes Content Security Policy violations for Google Analytics and implements clean separation between development and production configurations.

## Issues Fixed
- **CSP Violations**: Resolves `stats.g.doubleclick.net` connection errors by adding Google Analytics domains to CSP headers
- **Configuration Complexity**: Separates production config into dedicated `wrangler.prod.toml` for cleaner deployment management

## Changes Made

### 🔒 CSP Headers Updated
- **security-config.ts**: Updated default CSP policy to include Google Analytics domains
- **worker.js**: Added GA domains to frontend CSP headers (both dynamic and static)
- **_headers**: Updated static asset CSP to allow Google Analytics connections

**New CSP includes**:
- `script-src` → Added `https://www.googletagmanager.com`
- `img-src` → Added `https://www.google-analytics.com`
- `connect-src` → Added GA domains: `https://www.google-analytics.com`, `https://analytics.google.com`, `https://www.googletagmanager.com`, `https://stats.g.doubleclick.net`

### 🏗️ Configuration Separation
- **Created** `wrangler.prod.toml` with production-only settings
- **Removed** `[env.production]` section from main `wrangler.toml`
- **Updated** deployment commands in documentation

### 📚 Documentation Updates
- Updated `.claude/CLAUDE.md` with production deployment command
- Modified debugging lessons to reflect separate config approach
- Updated project structure documentation

## Test Plan
- [ ] Verify Google Analytics tracking works without CSP errors
- [ ] Test development deployment: `wrangler deploy`
- [ ] Test production deployment: `wrangler deploy --config wrangler.prod.toml`
- [ ] Confirm both environments maintain proper security headers

🤖 Generated with [Claude Code](https://claude.ai/code)